### PR TITLE
chore: add pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint

--- a/docs/proof/gitflow.md
+++ b/docs/proof/gitflow.md
@@ -1,0 +1,5 @@
+# Git Flow
+
+- main: stable
+- develop: integration
+- feature/*, chore/*, docs/*, fix/*: work branches

--- a/docs/proof/signed-commits.md
+++ b/docs/proof/signed-commits.md
@@ -1,0 +1,3 @@
+# Signed commits
+
+All commits are created with -S and must appear as Verified on GitHub.


### PR DESCRIPTION
## Summary
Add a pre-commit hook to run the linter before commits.

## Related issue
Closes #6 

## Type of change
- [ ] Feature
- [ ] Fix
- [ ] Docs
- [x] Chore

## Checklist
- [x] My commits are signed
- [x] I linked the issue
- [x] My branch targets develop